### PR TITLE
fix: rename block-fetch variables

### DIFF
--- a/cmd/block-fetch/main.go
+++ b/cmd/block-fetch/main.go
@@ -49,7 +49,7 @@ func main() {
 		Slot:         72316896,
 	}
 	// Parse environment variables
-	if err := envconfig.Process("cardano_node", &cfg); err != nil {
+	if err := envconfig.Process("block_fetch", &cfg); err != nil {
 		panic(err)
 	}
 	// Configure NetworkMagic


### PR DESCRIPTION
Use BLOCK_FETCH as the prefix instead of CARDANO_NODE since we are not using any Demeter provided variables for configuration.