### PR TITLE
feat: add tx-submission command for LocalTxSubmission protocol

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,8 @@
 /chain-tip
 /peer-sharing
 /tx-monitor
+/chain-sync
+/tx-submission
 
 # Test binary, built with `go test -c`
 *.test

--- a/README.md
+++ b/README.md
@@ -49,6 +49,7 @@ protocol and provides examples of multiple Ouroboros mini-protocols.
 - BlockFetch
 - ChainSync
 - LocalTxMonitor
+- LocalTxSubmission
 - PeerSharing
 
 ### BlockFetch
@@ -110,6 +111,35 @@ go run ./cmd/tx-monitor
 ```
 
 The script will output the contents of the Cardano Node's mempool, then exits.
+
+### LocalTxSubmission
+
+This starter kit demonstrates communication with a Cardano Node using the
+Node-to-Client LocalTxSubmission protocol to submit transactions to the Node's
+mempool. It includes a single `main.go` which performs all of the work, which
+is located under `cmd/tx-submission`.
+
+The default configuration will communicate over the local UNIX socket mounted
+at `/ipc/node.socket` via Node-to-Client LocalTxSubmission.
+
+Command-line flags:
+
+- `-tx-file`: Path to a JSON transaction file (must contain `cborHex` field)
+- `-raw-tx-file`: Path to a raw CBOR transaction file
+
+Examples:
+
+Submit a transaction from a JSON file:
+```bash
+go run ./cmd/tx-submission -tx-file transaction.json
+```
+
+Submit a transaction from a raw CBOR file:
+```bash
+go run ./cmd/tx-submission -raw-tx-file transaction.cbor
+```
+
+The script will output a success message if the transaction was accepted by the node.
 
 ### PeerSharing
 

--- a/cmd/tx-submission/main.go
+++ b/cmd/tx-submission/main.go
@@ -1,0 +1,148 @@
+// Copyright 2025 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"encoding/hex"
+	"encoding/json"
+	"flag"
+	"fmt"
+	"os"
+
+	ouroboros "github.com/blinklabs-io/gouroboros"
+	"github.com/blinklabs-io/gouroboros/ledger"
+	"github.com/blinklabs-io/gouroboros/protocol/localtxsubmission"
+	"github.com/kelseyhightower/envconfig"
+)
+
+// We parse environment variables using envconfig into this struct
+type Config struct {
+	Magic      uint32
+	SocketPath string `split_words:"true"`
+	Network    string
+	TxFile     string
+	RawTxFile  string
+}
+
+// This code will be executed when run
+func main() {
+	// Set config defaults
+	cfg := Config{
+		SocketPath: "/ipc/node.socket",
+	}
+	// Parse environment variables
+	if err := envconfig.Process("cardano_node", &cfg); err != nil {
+		panic(err)
+	}
+
+	// Parse command-line flags
+	flag.StringVar(&cfg.TxFile, "tx-file", "", "path to the JSON transaction file to submit")
+	flag.StringVar(&cfg.RawTxFile, "raw-tx-file", "", "path to the raw transaction file to submit")
+	flag.Parse()
+
+	// Validate that at least one transaction file is provided
+	if cfg.TxFile == "" && cfg.RawTxFile == "" {
+		fmt.Printf("ERROR: you must specify -tx-file or -raw-tx-file\n")
+		os.Exit(1)
+	}
+
+	// Configure NetworkMagic
+	if cfg.Magic == 0 {
+		if cfg.Network == "" {
+			// Default to preview network if not specified
+			cfg.Network = "preview"
+		}
+		network, ok := ouroboros.NetworkByName(cfg.Network)
+		if !ok {
+			fmt.Printf("ERROR: invalid network specified: %v\n", cfg.Network)
+			os.Exit(1)
+		}
+		cfg.Magic = network.NetworkMagic
+	}
+
+	// Create error channel
+	errorChan := make(chan error)
+	// Start error handler
+	go func() {
+		for {
+			err := <-errorChan
+			fmt.Printf("ERROR: %s\n", err)
+			os.Exit(1)
+		}
+	}()
+
+	// Configure Ouroboros
+	o, err := ouroboros.NewConnection(
+		ouroboros.WithNetworkMagic(cfg.Magic),
+		ouroboros.WithErrorChan(errorChan),
+		ouroboros.WithNodeToNode(false), // Use NtC protocol (UNIX socket)
+		ouroboros.WithKeepAlive(true),
+		ouroboros.WithLocalTxSubmissionConfig(localtxsubmission.NewConfig()),
+	)
+	if err != nil {
+		fmt.Printf("ERROR: %s\n", err)
+		os.Exit(1)
+	}
+
+	// Connect to Node socket
+	if err = o.Dial("unix", cfg.SocketPath); err != nil {
+		fmt.Printf("ERROR: connection failed: %s\n", err)
+		os.Exit(1)
+	}
+
+	// Load transaction bytes
+	var txBytes []byte
+	if cfg.TxFile != "" {
+		txData, err := os.ReadFile(cfg.TxFile)
+		if err != nil {
+			fmt.Printf("ERROR: failed to load transaction file: %s\n", err)
+			os.Exit(1)
+		}
+
+		var jsonData map[string]string
+		err = json.Unmarshal(txData, &jsonData)
+		if err != nil {
+			fmt.Printf("ERROR: failed to parse transaction file: %s\n", err)
+			os.Exit(1)
+		}
+
+		txBytes, err = hex.DecodeString(jsonData["cborHex"])
+		if err != nil {
+			fmt.Printf("ERROR: failed to decode transaction: %s\n", err)
+			os.Exit(1)
+		}
+	} else {
+		txBytes, err = os.ReadFile(cfg.RawTxFile)
+		if err != nil {
+			fmt.Printf("ERROR: failed to load transaction file: %s\n", err)
+			os.Exit(1)
+		}
+	}
+
+	// Determine transaction type from raw bytes
+	txType, err := ledger.DetermineTransactionType(txBytes)
+	if err != nil {
+		fmt.Printf("ERROR: failed to determine transaction type: %s\n", err)
+		os.Exit(1)
+	}
+
+	// Submit transaction
+	if err = o.LocalTxSubmission().Client.SubmitTx(uint16(txType) /* #nosec G115 */, txBytes); err != nil {
+		fmt.Printf("ERROR: failed to submit transaction: %s\n", err)
+		os.Exit(1)
+	}
+
+	fmt.Print("The transaction was accepted\n")
+}


### PR DESCRIPTION
Closes #31 

refs:
- #31 
- https://github.com/blinklabs-io/gouroboros/issues/193

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a tx-submission CLI that submits transactions to a local Cardano node using the Node-to-Client LocalTxSubmission protocol. Supports JSON (cborHex) and raw CBOR inputs, with sane defaults and clear errors.

- New Features
  - Added cmd/tx-submission to submit transactions over UNIX socket via LocalTxSubmission.
  - Supports -tx-file (JSON with cborHex) and -raw-tx-file (raw CBOR); auto-detects tx type.
  - Configurable via env (CARDANO_NODE_SOCKET_PATH, CARDANO_NODE_NETWORK or CARDANO_NODE_MAGIC); defaults to /ipc/node.socket and preview.
  - Updated README with usage examples; added ignore entries for new binary.

<sup>Written for commit 38ff2e7986b63c89613e58aa35b2fc6363be60f5. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new command-line tool for submitting transactions to a Cardano node with configurable socket paths and support for multiple transaction formats.

* **Documentation**
  * Updated protocol documentation to include LocalTxSubmission protocol details with configuration options and usage examples.

* **Chores**
  * Updated build artifact exclusions.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->